### PR TITLE
Add eth-utils code to eip55

### DIFF
--- a/EIPS/eip-55.md
+++ b/EIPS/eip-55.md
@@ -13,25 +13,47 @@ created: 2016-01-14
 Code:
 
 ``` python
-from ethereum import utils
+import eth_utils
+
 
 def checksum_encode(addr): # Takes a 20-byte binary address as input
-    o = ''
-    v = utils.big_endian_to_int(utils.keccak256(addr.hex()))
-    for i, c in enumerate(addr.hex()):
-        if c in '0123456789':
-            o += c
+    hex_addr = addr.hex()
+    checksummed_buffer = ""
+
+    # Treat the hex address as ascii/utf-8 for keccak256 hashing
+    hashed_address = eth_utils.keccak(text=hex_addr).hex()
+
+    # Iterate over each character in the hex address
+    for nibble_index, character in enumerate(hex_addr):
+
+        if character in "0123456789":
+            # We can't upper-case the decimal digits
+            checksummed_buffer += character
+        elif character in "abcdef":
+            # Check if the corresponding hex digit (nibble) in the hash is 8 or higher
+            hashed_address_nibble = int(hashed_address[nibble_index], 16)
+            if hashed_address_nibble > 7:
+                checksummed_buffer += character.upper()
+            else:
+                checksummed_buffer += character
         else:
-            o += c.upper() if (v & (2**(255 - 4*i))) else c.lower()
-    return '0x'+o
+            raise eth_utils.ValidationError(
+                f"Unrecognized hex character {character!r} at position {nibble_index}"
+            )
 
-def test(addrstr):
-    assert(addrstr == checksum_encode(bytes.fromhex(addrstr[2:])))
+    return "0x" + checksummed_buffer
 
-test('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed')
-test('0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359')
-test('0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB')
-test('0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb')
+
+def test(addr_str):
+    addr_bytes = eth_utils.to_bytes(hexstr=addr_str)
+    checksum_encoded = checksum_encode(addr_bytes)
+    assert checksum_encoded == addr_str, f"{checksum_encoded} != expected {addr_str}"
+
+
+test("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")
+test("0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359")
+test("0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB")
+test("0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb")
 
 ```
 


### PR DESCRIPTION
Replace the pyethereum code, because it's deprecated, and because it
uses the name "sha3" for the hashing function, rather than the clearer
"keccak".

Included some more commentary on the code, as well.